### PR TITLE
letter_opener_webと関連する設定を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'letter_opener_web', '~> 3.0'
   gem 'web-console'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,6 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
@@ -92,7 +90,6 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.3.0)
-    childprocess (5.0.0)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -130,16 +127,6 @@ GEM
       activesupport (>= 5.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    launchy (3.0.1)
-      addressable (~> 2.8)
-      childprocess (~> 5.0)
-    letter_opener (1.10.0)
-      launchy (>= 2.2, < 4)
-    letter_opener_web (3.0.0)
-      actionmailer (>= 6.1)
-      letter_opener (~> 1.9)
-      railties (>= 6.1)
-      rexml
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -183,7 +170,6 @@ GEM
     pg (1.5.6)
     psych (5.1.2)
       stringio
-    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -344,7 +330,6 @@ DEPENDENCIES
   factory_bot_rails
   html2slim!
   jbuilder
-  letter_opener_web (~> 3.0)
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.0)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,5 +73,4 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
-  config.action_mailer.delivery_method = :letter_opener_web
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,4 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## Issue

- https://github.com/natsuto6/ruby-uchi/issues/89

## PRの種類
- [ ] 🌟 Feature: 機能追加
- [x] 🐞 Bug Fix: バグ修正
- [ ] 📚 Documentation Update: ドキュメント更新
- [ ] 🎨 Style: コードのスタイル変更（動作に影響なし）
- [ ] 🛠️ Code Refactor: リファクタリング
- [ ] 🚀 Performance Improvements: パフォーマンス向上
- [ ] ✅ Test: テスト関連の変更
- [ ] 🤖 Build: ビルド関連の変更
- [ ] 🔁 CI: 継続的インテグレーションの設定
- [ ] 🗂️ Chore: その他の変更
- [ ] 🔙 Revert: 変更の取り消し

## 変更内容詳細

- letter_opener_webと関連する設定を削除した


## 動作確認方法

<!--
例:
1. {branch_name}をローカルに取り込む
2.
-->

## スクリーンショット

### 変更前

### 変更後

## その他

- development環境でのみ使用されるべきであるのに、production環境でも読み込まれているため、エラーが出力されていた
- 違う方法を使ってメールを確認する方法も考慮する
- 下手に修正を加えず必要であれば再度導入する
